### PR TITLE
fix: correct creatPopper link

### DIFF
--- a/src/pages/react-popper/v2/hook.mdx
+++ b/src/pages/react-popper/v2/hook.mdx
@@ -6,7 +6,7 @@ order: 1
 # React Hook
 
 The `usePopper` hook provides an API almost identical to the ones of
-[`createPopper`](../../docs/v2/constructors/#createpopper) constructor.
+[`createPopper`](../../../docs/v2/constructors/#createpopper) constructor.
 
 Rather than returning a Popper instance, it will return an object containing the
 following properties:


### PR DESCRIPTION
I corrected the link to the `createPopper` docs

Let me know if I should rebase to `gh-pages`