### PR TITLE
Fix react-popper docs' createPopper link

### DIFF
--- a/src/pages/react-popper/v2/hook.mdx
+++ b/src/pages/react-popper/v2/hook.mdx
@@ -6,7 +6,7 @@ order: 1
 # React Hook
 
 The `usePopper` hook provides an API almost identical to the ones of
-[`createPopper`](../../docs/v2/constructors/#createpopper) constructor.
+[`createPopper`](../../../docs/v2/constructors/#createpopper) constructor.
 
 Rather than returning a Popper instance, it will return an object containing the
 following properties:


### PR DESCRIPTION
The `createPopper` link [in react-popper docs](https://popper.js.org/docs/v2/constructors/#createpopper) leads to 404 at https://popper.js.org/react-popper/docs/v2/constructors/#createpopper.

Now it leads to `https://popper.js.org/docs/v2/constructors/#createpopper`, which is the proper destination.