### PR TITLE
Add explanation for using usePopper callback ref

### DIFF
--- a/src/pages/react-popper/v2/index.mdx
+++ b/src/pages/react-popper/v2/index.mdx
@@ -60,3 +60,9 @@ const Example = () => {
   );
 };
 ```
+
+> Note: the `usePopper` hook intentionally takes the DOM node, not refs,
+> in order to be able to update when the nodes change.
+> A [`callback ref`](https://reactjs.org/docs/refs-and-the-dom.html#callback-refs)
+> is used here to permit this behaviour, and `useState` is an appropriate way to
+> implement this.


### PR DESCRIPTION
I've seen a bit of confusion & questioning for why the `usePopper` hook uses `useState` with `callback refs` rather than just using `useRef`. This PR adds a brief explanation for the reasoning.

As per commit description:
```
Adds a small explanation for why `useState` is used over `useRef.  
The explanation is a 'key  points' summarization taken from:  
https://github.com/popperjs/react-popper/issues/241#issuecomment-591411605
```