### PR TITLE
Fix: Add String.prototype.includes in polyfill.io url

### DIFF
--- a/src/pages/docs/v2/browser-support.mdx
+++ b/src/pages/docs/v2/browser-support.mdx
@@ -17,7 +17,7 @@ IE11 (and older browsers in general) require polyfills to work. The simplest way
 to make Popper work is to use the following polyfill service:
 
 ```html
-<script src="https://polyfill.io/v3/polyfill.min.js?features=Array.prototype.find,Promise,Object.assign"></script>
+<script src="https://polyfill.io/v3/polyfill.min.js?features=Array.prototype.find,Promise,Object.assign,String.prototype.includes"></script>
 ```
 
 Browsers that don't need the polyfills won't be burdened with the JS bundle


### PR DESCRIPTION
In a recent PR (https://github.com/popperjs/popper-core/pull/1244) String.prototype.includes is used for the first time, which isn't supported by IE11 (https://caniuse.com/es6-string-includes). Without the addition of a String.prototype.includes polyfill, popper won't work on IE.