### PR TITLE
Update migration-guide.mdx

### DIFF
--- a/src/pages/docs/v2/migration-guide.mdx
+++ b/src/pages/docs/v2/migration-guide.mdx
@@ -91,8 +91,8 @@ createPopper(reference, popper, {
 
 ## 8. Update method names
 
-- `scheduleUpdate()` is now `update()` (and returns a promise)
 - `update()` is now `forceUpdate()` (and is sync)
+- `scheduleUpdate()` is now `update()` (and returns a promise)
 - `enableEventListeners` / `disableEventListeners` are gone; see the
   `eventListeners` modifier. You can use the `setOptions` method to change the
   `scroll` and `resize` options at will to replicate the original methods'


### PR DESCRIPTION
Swap 8.1 and 8.2

It makes confusion when you follow this guide step by step. Because you rename `scheduleUpdate()` to `update()`, and it becomes the same name with `update()` in the next step. To avoid this, we better swap these steps.