### PR TITLE
fix: remove scrollable prop for followCursor demo

### DIFF
--- a/src/components/Demos.js
+++ b/src/components/Demos.js
@@ -248,7 +248,7 @@ export const VirtualElementDemo = () => {
   });
 
   return (
-    <ClippingParent scrollable>
+    <ClippingParent>
       <Tooltip ref={popper}>Tooltip</Tooltip>
     </ClippingParent>
   );


### PR DESCRIPTION
Scrolling causes severe jittering with async scrolling in most browsers, and is not necessary to demonstrate here.

---

I also wanted to change the `preventOverflow` example on the landing page to avoid repositioning while "prevented" from overflowing (there are some jitters), but can't really demonstrate the feature succinctly unless the tooltip is inside the scrollable container

This section from tether.io could be useful on the `Performance` section:

<img width="790" alt="Screen Shot 2021-11-10 at 3 52 48 am" src="https://user-images.githubusercontent.com/22450188/140968682-10f0b551-787d-4133-803f-f9cd3e047516.png">