### PR TITLE
fix: silky smooth preventOverflow demo

### DIFF
--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -512,10 +512,19 @@ createPopper(popcorn, tooltip, {
 };
 
 const PreventOverflowExample = () => {
+  const [boundary, setBoundary] = useState();
   const scrollContainerRef = useRef();
 
   const { reference, popper } = usePopper({
     placement: 'right',
+    modifiers: [
+      {
+        name: 'preventOverflow',
+        options: {
+          boundary,
+        },
+      },
+    ],
   });
 
   useLayoutEffect(() => {
@@ -536,15 +545,23 @@ createPopper(popcorn, tooltip, {
 
   return (
     <ExampleBox>
-      <ScrollContainer ref={scrollContainerRef}>
-        <PopcornBox
-          ref={reference}
-          src={popcornBox}
-          css={css`
-            position: absolute;
-            left: 100px;
-          `}
-        />
+      <div
+        css={css`
+          position: relative;
+          overflow: hidden;
+        `}
+        ref={setBoundary}
+      >
+        <ScrollContainer ref={scrollContainerRef}>
+          <PopcornBox
+            ref={reference}
+            src={popcornBox}
+            css={css`
+              position: absolute;
+              left: 100px;
+            `}
+          />
+        </ScrollContainer>
         <Tooltip ref={popper}>
           <TooltipName>Popcorn</TooltipName>
           <TooltipName>sizes</TooltipName>
@@ -560,7 +577,7 @@ createPopper(popcorn, tooltip, {
 
           <Arrow data-popper-arrow />
         </Tooltip>
-      </ScrollContainer>
+      </div>
       <ExampleText>
         <Heading>
           <Crop /> Overflow prevention


### PR DESCRIPTION
This appends the `<Tooltip />` outside of the scrollable container, inside a new clipping parent. This makes the example work the same, but when the `<Tooltip />` is at the edge of the boundary (and prevented from overflowing), it will not stutter with async scrolling since it doesn't need to be repositioned. 

Chrome and Firefox back in early 2020 were fine with this, but have since changed their scrolling, so now this is required